### PR TITLE
Reverted lucius.vim change

### DIFF
--- a/autoload/airline/themes/lucius.vim
+++ b/autoload/airline/themes/lucius.vim
@@ -40,7 +40,7 @@ function! airline#themes#lucius#refresh()
     let g:airline#themes#lucius#palette.visual.airline_warning = g:airline#themes#lucius#palette.normal.airline_warning
     let g:airline#themes#lucius#palette.visual_modified.airline_warning = g:airline#themes#lucius#palette.normal_modified.airline_warning
 
-    let s:IA = airline#themes#get_highlight('CursorLine')
+    let s:IA = airline#themes#get_highlight('StatusLineNC')
     let g:airline#themes#lucius#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
     let g:airline#themes#lucius#palette.inactive_modified = {
                 \ 'airline_c': [ modified_group[0], '', modified_group[2], '', '' ]


### PR DESCRIPTION
The change made yesterday made the inactive line indistinguishable from CursorLine, so it becomes very hard to tell the difference between the current line and a status line. If a different inactive status line is wanted, can the person who wants it create a variable instead where they can set the color to use?