### PR TITLE
Tweak jellybeans for more readability, information

### DIFF
--- a/autoload/airline/themes/jellybeans.vim
+++ b/autoload/airline/themes/jellybeans.vim
@@ -27,46 +27,54 @@ let s:cterm07 = "189"
 let s:cterm08 = "88"
 let s:cterm09 = "209"
 let s:cterm0A = "221"
-let s:cterm0B = "64"
+let s:cterm0B = "22"
 let s:cterm0C = "73"
 let s:cterm0D = "25"
 let s:cterm0E = "176"
 let s:cterm0F = "137"
 
 let s:guiWhite = "#ffffff"
+let s:guiGray = "#666666"
 let s:ctermWhite = "231"
+let s:ctermGray = "243"
 
 let g:airline#themes#jellybeans#palette = {}
+let s:modified = { 'airline_c': [ '#ffb964', '', 215, '', '' ] }
 
 " Normal mode
 let s:N1 = [ s:gui07 , s:gui0D , s:cterm07 , s:cterm0D  ]
 let s:N2 = [ s:guiWhite , s:gui01 , s:ctermWhite , s:cterm01  ]
 let s:N3 = [ s:gui02 , s:gui00 , s:cterm02 , s:cterm00  ]
 let g:airline#themes#jellybeans#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
+let g:airline#themes#jellybeans#palette.normal_modified = s:modified
 
 " Insert mode
 let s:I1 = [ s:guiWhite , s:gui0B , s:ctermWhite , s:cterm0B  ]
-let s:I2 = [ s:gui02 , s:gui01 , s:cterm03 , s:cterm01  ]
+let s:I2 = s:N2
 let s:I3 = [ s:guiWhite , s:gui01 , s:ctermWhite , s:cterm00  ]
 let g:airline#themes#jellybeans#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
+let g:airline#themes#jellybeans#palette.insert_modified = s:modified
 
 " Visual mode
 let s:V1 = [ s:guiWhite , s:gui08 , s:ctermWhite , s:cterm08 ]
-let s:V2 = [ s:gui02 , s:gui01 , s:cterm03 , s:cterm01  ]
-let s:V3 = [ s:guiWhite , s:gui01 , s:ctermWhite , s:cterm00  ]
+let s:V2 = s:N2
+let s:V3 = s:I3
 let g:airline#themes#jellybeans#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
+let g:airline#themes#jellybeans#palette.visual_modified = s:modified
 
 " Replace mode
 let s:R1 = [ s:gui08 , s:gui01 , s:cterm08, s:cterm00 ]
-let s:R2 = [ s:gui02 , s:gui01 , s:cterm03 , s:cterm01  ]
-let s:R3 = [ s:guiWhite , s:gui01 , s:ctermWhite , s:cterm00  ]
+let s:R2 = s:N2
+let s:R3 = s:I3
 let g:airline#themes#jellybeans#palette.replace = airline#themes#generate_color_map(s:R1, s:R2, s:R3)
+let g:airline#themes#jellybeans#palette.replace_modified = s:modified
 
 " Inactive mode
-let s:IN1 = [ s:gui00 , s:gui01 , s:cterm00 , s:cterm01 ]
+let s:IN1 = [ s:guiGray , s:gui01 , s:ctermGray , s:cterm01 ]
 let s:IN2 = [ s:gui02 , s:gui00 , s:cterm02 , s:cterm00 ]
 let s:IN3 = [ s:gui02 , s:gui00 , s:cterm02 , s:cterm00 ]
 let g:airline#themes#jellybeans#palette.inactive = airline#themes#generate_color_map(s:IN1, s:IN2, s:IN3)
+let g:airline#themes#jellybeans#palette.inactive_modified = s:modified
 
 " CtrlP
 if !get(g:, 'loaded_ctrlp', 0)


### PR DESCRIPTION
OK, a much smaller set of tweaks I wanted to see:

- darken green background of INSERT (to match original)
- restore orange modified highlight
- unify 2nd sections, deduplicate 3rd sections
- make sides of inactive bar brighter for better readability

I know this is largely a matter of taste, but hopefully these are reasonably uncontroversial. I think points 1 and 4 increase readability, point 2 adds information, point 3 is partly bookkeeping and partly changing the rather counterintuitive way the center sections brighten and the 2nd sections darken simultaneously when switching from Normal to anything else.