### PR TITLE
Ignore tags files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
I noticed that you ignore `doc/tags` in the `vim-airline/vim-airline`
repo but not this one.

Feel free to close if this is not something you want in this project's
gitignore.