### PR TITLE
Add green option to solarized theme

### DIFF
--- a/autoload/airline/themes/solarized.vim
+++ b/autoload/airline/themes/solarized.vim
@@ -6,6 +6,7 @@ function! airline#themes#solarized#refresh()
   """"""""""""""""""""""""""""""""""""""""""""""""
   let s:background  = get(g:, 'airline_solarized_bg', &background)
   let s:ansi_colors = get(g:, 'solarized_termcolors', 16) != 256 && &t_Co >= 16 ? 1 : 0
+  let s:use_green   = get(g:, 'airline_solarized_normal_green', 0)
   let s:tty         = &t_Co == 8
 
   """"""""""""""""""""""""""""""""""""""""""""""""
@@ -58,11 +59,11 @@ function! airline#themes#solarized#refresh()
   """"""""""""""""""""""""""""""""""""""""""""""""
   " Normal mode
   if s:background == 'dark'
-    let s:N1 = [s:base3, s:base1, 'bold']
+    let s:N1 = [s:base3, (s:use_green ? s:green : s:base1), 'bold']
     let s:N2 = [s:base2, (s:tty ? s:base01 : s:base00), '']
     let s:N3 = [s:base01, s:base02, '']
   else
-    let s:N1 = [s:base2, s:base00, 'bold']
+    let s:N1 = [s:base2, (s:use_green ? s:green : s:base00), 'bold']
     let s:N2 = [(s:tty ? s:base01 : s:base2), s:base1, '']
     let s:N3 = [s:base1, s:base2, '']
   endif

--- a/doc/airline-themes.txt
+++ b/doc/airline-themes.txt
@@ -115,6 +115,13 @@ Base16 Shell.  To enable it:
 >
 See also https://github.com/blueyed/vim-colors-solarized/commit/92f2f994.
 
+*g:airline_solarized_normal_green*
+
+Turns the outer-most section of the statusline Solarized green, making it
+look more like classic powerline in normal mode. To enable it:
+>
+    let g:airline_solarized_normal_green = 1
+
 ==============================================================================
 CONTRIBUTIONS                                *airline-themes-contributions*
 


### PR DESCRIPTION
Turns the outer-most section of the statusline Solarized green, making it
look more like classic powerline in normal mode. To enable it:

```
let g:airline_solarized_normal_green = 1
```

By default, the theme is unchanged. Only when this option is enabled are any
changes visible.