### PR TITLE
powerlineish: improve inactive status line

### DIFF
--- a/autoload/airline/themes/powerlineish.vim
+++ b/autoload/airline/themes/powerlineish.vim
@@ -41,6 +41,6 @@ let g:airline#themes#powerlineish#palette.replace = copy(airline#themes#powerlin
 let g:airline#themes#powerlineish#palette.replace.airline_a = [ s:RE[0] , s:RE[1] , s:RE[2] , s:RE[3] , '' ]
 
 
-let s:IA = [ s:N2[1] , s:N3[1] , s:N2[3] , s:N3[3] , '' ]
+let s:IA = [ s:N2[0] , s:N3[1] , s:N2[2] , s:N3[3] , '' ]
 let g:airline#themes#powerlineish#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
 


### PR DESCRIPTION
The inactive status line is really hard to see. I have tweaked the foreground color to improve visibility.

Before:
![before](https://cloud.githubusercontent.com/assets/238528/16603645/a6fc41c8-42eb-11e6-838a-209cc3f81528.jpg)

Now:
![after](https://cloud.githubusercontent.com/assets/238528/16603646/a8c3ad2a-42eb-11e6-9371-f051d339cf2f.jpg)
