### PR TITLE
[term] change mode colors for gvim to be more compact with the theme.

### DIFF
--- a/autoload/airline/themes/term.vim
+++ b/autoload/airline/themes/term.vim
@@ -5,25 +5,25 @@
 
 " Normal mode
 "          [ guifg, guibg, ctermfg, ctermbg, opts ]
-let s:N1 = [ '#141413' , '#CAE682' , 232 , 2 ] " mode
+let s:N1 = [ '#141413' , '#008000' , 232 , 2 ] " mode
 let s:N2 = [ '#CAE682' , '#32322F' , 2 , 'black' ] " info
 let s:N3 = [ '#CAE682' , '#242424' , 2 , 233 ] " statusline
-let s:N4 = [ '#86CD74' , 10 ]                   " mode modified
+let s:N4 = [ '#57B240' , 10 ]                   " mode modified
 
 " Insert mode
-let s:I1 = [ '#141413' , '#FDE76E' , 232 , 3 ]
+let s:I1 = [ '#141413' , '#808000' , 232 , 3 ]
 let s:I2 = [ '#FDE76E' , '#32322F' , 3 , 'black' ]
 let s:I3 = [ '#FDE76E' , '#242424' , 3 , 233 ]
 let s:I4 = [ '#FADE3E' , 11 ]
 
 " Visual mode
-let s:V1 = [ '#141413' , '#B5D3F3' , 232 , 4 ]
+let s:V1 = [ '#141413' , '#185391' , 232 , 4 ]
 let s:V2 = [ '#B5D3F3' , '#32322F' , 4 , 'black' ]
 let s:V3 = [ '#B5D3F3' , '#242424' , 4 , 233 ]
 let s:V4 = [ '#7CB0E6' , 12 ]
 
 " Replace mode
-let s:R1 = [ '#141413' , '#E5786D' , 232 , 1 ]
+let s:R1 = [ '#141413' , '#e20000' , 232 , 1 ]
 let s:R2 = [ '#E5786D' , '#32322F' , 1 , 'black' ]
 let s:R3 = [ '#E5786D' , '#242424' , 1 , 233 ]
 let s:R4 = [ '#E55345' , 9 ]


### PR DESCRIPTION
Mode colors in GVim looks pale (pastel). This is how they look

before:
![screenshot from 2016-09-15 01 51 20](https://cloud.githubusercontent.com/assets/16504838/18534047/ffcdcdba-7ae7-11e6-8c71-e79b1de9ac2a.png)
![screenshot from 2016-09-15 01 51 36](https://cloud.githubusercontent.com/assets/16504838/18534048/fff20284-7ae7-11e6-944c-2042f7938bfd.png)
![screenshot from 2016-09-15 01 51 42](https://cloud.githubusercontent.com/assets/16504838/18534050/00092fd6-7ae8-11e6-862f-089bf587ba74.png)
![screenshot from 2016-09-15 01 51 51](https://cloud.githubusercontent.com/assets/16504838/18534049/0002f3fa-7ae8-11e6-9965-af746b542c4d.png)

after:
![screenshot from 2016-09-15 01 34 49](https://cloud.githubusercontent.com/assets/16504838/18534058/0a8ab89e-7ae8-11e6-8cc8-b9676d281194.png)
![screenshot from 2016-09-15 01 35 02](https://cloud.githubusercontent.com/assets/16504838/18534059/0a8b6366-7ae8-11e6-9e91-b6373d39ddda.png)
![screenshot from 2016-09-15 01 35 10](https://cloud.githubusercontent.com/assets/16504838/18534060/0a8b77ac-7ae8-11e6-86ff-e046241693c1.png)
![screenshot from 2016-09-15 01 35 18](https://cloud.githubusercontent.com/assets/16504838/18534061/0a94b574-7ae8-11e6-8b19-ca7c59b17432.png)
