### PR TITLE
Check base16colorspace = 256 color in oceanicnext

### DIFF
--- a/autoload/airline/themes/base16_oceanicnext.vim
+++ b/autoload/airline/themes/base16_oceanicnext.vim
@@ -18,22 +18,32 @@ let s:gui0D = "#6699cc"
 let s:gui0E = "#c594c5"
 let s:gui0F = "#ab7967"
 
+" Terminal color definitions
 let s:cterm00 = 00
-let s:cterm01 = 10
-let s:cterm02 = 11
 let s:cterm03 = 08
-let s:cterm04 = 12
 let s:cterm05 = 07
-let s:cterm06 = 13
 let s:cterm07 = 15
 let s:cterm08 = 01
-let s:cterm09 = 09
 let s:cterm0A = 03
 let s:cterm0B = 02
 let s:cterm0C = 06
 let s:cterm0D = 04
 let s:cterm0E = 05
-let s:cterm0F = 14
+if exists('base16colorspace') && base16colorspace == "256"
+  let s:cterm01 = 18
+  let s:cterm02 = 19
+  let s:cterm04 = 20
+  let s:cterm06 = 21
+  let s:cterm09 = 16
+  let s:cterm0F = 17
+else
+  let s:cterm01 = 10
+  let s:cterm02 = 11
+  let s:cterm04 = 12
+  let s:cterm06 = 13
+  let s:cterm09 = 09
+  let s:cterm0F = 14
+endif
 
 let s:N1   = [ s:gui01, s:gui0B, s:cterm01, s:cterm0B ]
 let s:N2   = [ s:gui06, s:gui02, s:cterm06, s:cterm02 ]

--- a/doc/airline-themes.txt
+++ b/doc/airline-themes.txt
@@ -176,9 +176,16 @@ colors in the terminal: (https://github.com/chriskempson/base16-shell). The
 colors used in this theme are within the 21 term colors set by Base16 Shell.
 The theme supports 2 options described below.
 
+*g:airline_base16_oceanicnext*
+
+Allow 256 color use of the base16_oceanicnext theme. Without this setting
+base16_oceanicnext may look incorrect in 256 color mode. To enable it: >
+
+    let base16colorspace = 256
+
 *g:airline_base16_solarized*
 
-Adjusts the colors to match base16_solirazed shell theme. You may also try to
+Adjusts the colors to match base16_solarized shell theme. You may also try to
 use it with other Base16 Shell themes. To enable it: >
 
     let g:airline_base16_solarized = 1


### PR DESCRIPTION
- This fixes the airline if you're running with 256 colors
  matching the base16 colorscheme setup for oceanicnext