### PR TITLE
hybrid: makes colors consistent across the modes

### DIFF
--- a/autoload/airline/themes/hybrid.vim
+++ b/autoload/airline/themes/hybrid.vim
@@ -19,8 +19,8 @@ function! airline#themes#hybrid#refresh()
     let g:airline#themes#hybrid#palette.normal_modified.airline_warning = warning_group
 
     let s:I1 = airline#themes#get_highlight2(['Text', 'fg'], ['DiffText', 'bg'], 'bold')
-    let s:I2 = airline#themes#get_highlight2(['Text', 'fg'], ['SpellLocal', 'bg'], 'bold')
-    let s:I3 = airline#themes#get_highlight2(['Text', 'fg'], ['SpellCap', 'bg'], 'bold')
+    let s:I2 = s:N2
+    let s:I3 = s:N3
     let g:airline#themes#hybrid#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
     let g:airline#themes#hybrid#palette.insert_modified = g:airline#themes#hybrid#palette.normal_modified
     let g:airline#themes#hybrid#palette.insert.airline_warning = g:airline#themes#hybrid#palette.normal.airline_warning
@@ -35,9 +35,9 @@ function! airline#themes#hybrid#refresh()
     let g:airline#themes#hybrid#palette.replace.airline_warning = g:airline#themes#hybrid#palette.normal.airline_warning
     let g:airline#themes#hybrid#palette.replace_modified.airline_warning = g:airline#themes#hybrid#palette.replace_modified.airline_warning
 
-    let s:V1 = airline#themes#get_highlight2(['Text', 'fg'], ['Folded', 'bg'], 'bold')
-    let s:V2 = airline#themes#get_highlight2(['Text', 'fg'], ['DiffDelete', 'bg'], 'bold')
-    let s:V3 = airline#themes#get_highlight2(['Text', 'fg'], ['Error', 'bg'], 'bold')
+    let s:V1 = airline#themes#get_highlight2(['Text', 'fg'], ['DiffDelete', 'bg'], 'bold')
+    let s:V2 = s:N2
+    let s:V3 = s:N3
     let g:airline#themes#hybrid#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
     let g:airline#themes#hybrid#palette.visual_modified = g:airline#themes#hybrid#palette.normal_modified
     let g:airline#themes#hybrid#palette.visual.airline_warning = g:airline#themes#hybrid#palette.normal.airline_warning


### PR DESCRIPTION
hybrid.vim theme for airline uses pretty strange palette for both visual
and insert modes. Despite looking *strange*, one may consider it as a
design decision, however, the replace mode uses the same palette for
statusline as the normal mode and hence looks consistent. Visual
comparison could is located here:

    http://imgur.com/a/YoeMS

This patch makes things consistent and use the same colors for the
status line, and different colors for mode indicator.