### PR TITLE
hybrid: do not use any colors for modified state

### DIFF
--- a/autoload/airline/themes/hybrid.vim
+++ b/autoload/airline/themes/hybrid.vim
@@ -8,11 +8,7 @@ function! airline#themes#hybrid#refresh()
     let s:N2 = airline#themes#get_highlight('CursorLine')
     let s:N3 = airline#themes#get_highlight('PMenu')
     let g:airline#themes#hybrid#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
-
-    let modified_group = airline#themes#get_highlight2(['Text', 'fg'], ['SpellRare', 'bg'], 'bold')
-    let g:airline#themes#hybrid#palette.normal_modified = {
-                \ 'airline_c': airline#themes#get_highlight2(['Text', 'fg'], ['SpellRare', 'bg'], 'bold')
-                \ }
+    let g:airline#themes#hybrid#palette.normal_modified = {}
 
     let warning_group = airline#themes#get_highlight('SpellRare')
     let g:airline#themes#hybrid#palette.normal.airline_warning = warning_group
@@ -45,9 +41,7 @@ function! airline#themes#hybrid#refresh()
 
     let s:IA = airline#themes#get_highlight('StatusLineNC')
     let g:airline#themes#hybrid#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
-    let g:airline#themes#hybrid#palette.inactive_modified = {
-                \ 'airline_c': [ modified_group[0], '', modified_group[2], '', '' ]
-                \ }
+    let g:airline#themes#hybrid#palette.inactive_modified = g:airline#themes#hybrid#palette.normal_modified
 
     let g:airline#themes#hybrid#palette.accents = {
                 \ 'red': airline#themes#get_highlight('Constant'),


### PR DESCRIPTION
hybrid.vim theme for airline uses crimson color for status line if any
modifications to the buffer are detected. It looks annoying since we
deal with it every day. Let's do not be too obsessive here and get rid
of special color at all - fortunately it's redundant as we have [+] sign
to emphasize that unsaved changes are detected.

http://imgur.com/a/DAmmd