### PR TITLE
Add base16-spacemacs theme

### DIFF
--- a/autoload/airline/themes/base16_spacemacs.vim
+++ b/autoload/airline/themes/base16_spacemacs.vim
@@ -1,0 +1,142 @@
+" vim-airline base16-spacemacs theme by Peter Meehan (http://github.com/22a)
+" Base16 Spacemacs by Chris Kempson (http://chriskempson.com)
+" Spacemacs scheme by Nasser Alshammari (https://github.com/nashamri/spacemacs-theme)
+
+let s:gui00 = "#1f2022"
+let s:gui01 = "#282828"
+let s:gui02 = "#444155"
+let s:gui03 = "#585858"
+let s:gui04 = "#b8b8b8"
+let s:gui05 = "#a3a3a3"
+let s:gui06 = "#e8e8e8"
+let s:gui07 = "#f8f8f8"
+let s:gui08 = "#f2241f"
+let s:gui09 = "#ffa500"
+let s:gui0A = "#b1951d"
+let s:gui0B = "#67b11d"
+let s:gui0C = "#2d9574"
+let s:gui0D = "#4f97d7"
+let s:gui0E = "#a31db1"
+let s:gui0F = "#b03060"
+
+let s:cterm00 = 0
+let s:cterm01 = 18
+let s:cterm02 = 19
+let s:cterm03 = 8
+let s:cterm04 = 20
+let s:cterm05 = 7
+let s:cterm06 = 21
+let s:cterm07 = 15
+let s:cterm08 = 1
+let s:cterm09 = 16
+let s:cterm0A = 3
+let s:cterm0B = 2
+let s:cterm0C = 6
+let s:cterm0D = 4
+let s:cterm0E = 5
+let s:cterm0F = 17
+
+let g:airline#themes#base16_spacemacs#palette = {}
+
+" Background for branch and file format blocks
+let s:cterm_termbg    = s:cterm02
+let s:gui_termbg      = s:gui02
+" Foreground for branch and file format blocks
+let s:cterm_termfg    = s:cterm06
+let s:gui_termfg      = s:gui06
+
+
+" Background for middle block
+let s:cterm_termbg2   = s:cterm00
+let s:gui_termbg2     = s:gui00
+" Foreground for middle block
+let s:cterm_termfg2   = s:cterm06
+let s:gui_termfg2     = s:gui06
+
+
+" Background for normal mode and file position blocks
+let s:cterm_normalbg  = s:cterm0D
+let s:gui_normalbg    = s:gui0D
+" Foreground for normal mode and file position blocks
+let s:cterm_normalfg  = s:cterm07
+let s:gui_normalfg    = s:gui07
+
+
+" Background for insert mode and file position blocks
+let s:cterm_insertbg  = s:cterm0B
+let s:gui_insertbg    = s:gui0B
+" Foreground for insert mode and file position blocks
+let s:cterm_insertfg  = s:cterm07
+let s:gui_insertfg    = s:gui07
+
+
+" Background for visual mode and file position blocks
+let s:cterm_visualbg  = s:cterm09
+let s:gui_visualbg    = s:gui09
+" Foreground for visual mode and file position blocks
+let s:cterm_visualfg  = s:cterm07
+let s:gui_visualfg    = s:gui07
+
+
+" Background for replace mode and file position blocks
+let s:cterm_replacebg = s:cterm08
+let s:gui_replacebg   = s:gui08
+" Foreground for replace mode and file position blocks
+let s:cterm_replacefg = s:cterm07
+let s:gui_replacefg   = s:gui07
+
+
+" Background for inactive mode
+let s:cterm_inactivebg = s:cterm02
+let s:gui_inactivebg   = s:gui02
+" Foreground for inactive mode
+let s:cterm_inactivefg = s:cterm04
+let s:gui_inactivefg   = s:gui04
+
+
+" Modified file alert color
+let s:cterm_alert     = s:cterm0E
+let s:gui_alert       = s:gui0E
+
+
+" Branch and file format
+let s:BB = [s:gui_termfg, s:gui_termbg, s:cterm_termfg, s:cterm_termbg] " Branch and file format blocks
+
+" Normal mode
+let s:N1 = [s:gui_normalfg, s:gui_normalbg, s:cterm_normalfg, s:cterm_normalbg] " Outside blocks in normal mode
+let s:N2 = [s:gui_termfg2, s:gui_termbg2, s:cterm_normalbg, s:cterm_termbg2]     " Middle block
+let g:airline#themes#base16_spacemacs#palette.normal = airline#themes#generate_color_map(s:N1, s:BB, s:N2)
+let g:airline#themes#base16_spacemacs#palette.normal_modified = {'airline_c': [s:gui_alert, s:gui_termbg2, s:cterm_alert, s:cterm_termbg2, 'bold'] ,}
+
+" Insert mode
+let s:I1 = [s:gui_insertfg, s:gui_insertbg, s:cterm_insertfg, s:cterm_insertbg] " Outside blocks in insert mode
+let s:I2 = [s:gui_insertbg, s:gui_termbg2, s:cterm_insertbg, s:cterm_termbg2]   " Middle block
+let g:airline#themes#base16_spacemacs#palette.insert = airline#themes#generate_color_map(s:I1, s:BB, s:I2)
+let g:airline#themes#base16_spacemacs#palette.insert_modified = {'airline_c': [s:gui_alert, s:gui_termbg2, s:cterm_alert, s:cterm_termbg2, 'bold'] ,}
+
+" Replace mode
+let s:R1 = [s:gui_replacefg, s:gui_replacebg, s:cterm_replacefg, s:cterm_replacebg]  " Outside blocks in replace mode
+let s:R2 = [s:gui_termfg, s:gui_termbg2, s:cterm_termfg, s:cterm_termbg2]            " Middle block
+let g:airline#themes#base16_spacemacs#palette.replace = airline#themes#generate_color_map(s:R1, s:BB, s:R2)
+let g:airline#themes#base16_spacemacs#palette.replace_modified = {'airline_c': [s:gui_alert, s:gui_termbg2, s:cterm_alert, s:cterm_termbg2, 'bold'] ,}
+
+" Visual mode
+let s:V1 = [s:gui_visualfg, s:gui_visualbg, s:cterm_visualfg, s:cterm_visualbg] " Outside blocks in visual mode
+let s:V2 = [s:gui_visualbg, s:gui_termbg2, s:cterm_visualbg, s:cterm_termbg2]   " Middle block
+let g:airline#themes#base16_spacemacs#palette.visual = airline#themes#generate_color_map(s:V1, s:BB, s:V2)
+let g:airline#themes#base16_spacemacs#palette.visual_modified = {'airline_c': [s:gui_alert, s:gui_termbg2, s:cterm_alert, s:cterm_termbg2, 'bold'] ,}
+
+" Inactive mode
+let s:IA1 = [s:gui_inactivefg, s:gui_inactivebg, s:cterm_inactivefg, s:cterm_inactivebg, '']
+let s:IA2 = [s:gui_inactivefg, s:gui_inactivebg, s:cterm_inactivefg, s:cterm_inactivebg, '']
+let s:IA3 = [s:gui_inactivefg, s:gui_inactivebg, s:cterm_inactivefg, s:cterm_inactivebg, '']
+let g:airline#themes#base16_spacemacs#palette.inactive = airline#themes#generate_color_map(s:IA1, s:IA2, s:IA3)
+
+" CtrlP plugin colors
+if !get(g:, 'loaded_ctrlp', 0)
+  finish
+endif
+let g:airline#themes#base16_spacemacs#palette.ctrlp = airline#extensions#ctrlp#generate_color_map(
+      \ [s:gui_normalfg, s:gui_normalbg, s:cterm_normalfg, s:cterm_normalbg, ''],
+      \ [s:gui_termfg, s:gui_termbg, s:cterm_termfg, s:cterm_termbg, ''],
+      \ [s:gui_termfg2, s:gui_termbg2, s:cterm_termfg2, s:cterm_termbg2, 'bold'])

--- a/doc/airline-themes.txt
+++ b/doc/airline-themes.txt
@@ -67,6 +67,7 @@ Currently this repository contains the following themes:
     * base16_seti
     * base16_shapeshifter
     * base16_solarized
+    * base16_spacemacs
     * base16_summerfruit
     * base16_tomorrow
     * base16_twilight


### PR DESCRIPTION
Adds a base16-spacemacs theme. It follows the same primary mode colours as [molokai](https://github.com/vim-airline/vim-airline-themes/blob/master/autoload/airline/themes/molokai.vim) _{normal:blue, insert:green, visual:yellow/orange, replace:red}_ but with the colour palette of the[ spacemacs variant](https://github.com/chriskempson/base16-vim/blob/master/colors/base16-spacemacs.vim) of the [base16 themeset](https://github.com/chriskempson/base16-vim).

Mode run-through:
![Mode run-through](https://cloud.githubusercontent.com/assets/7144173/24373154/5843d420-1328-11e7-9f05-aa169df1e290.gif)

Normal mode with trailing whitespace:
<img width="1256" alt="Normal mode with trailing whitespace" src="https://cloud.githubusercontent.com/assets/7144173/24372204/1710556c-1325-11e7-9fbe-46041b69ee54.png">

Normal mode with unwritten file modification:
<img width="1256" alt="Normal mode with unwritten file modification" src="https://cloud.githubusercontent.com/assets/7144173/24372407/c7a58640-1325-11e7-8b87-0f903e102d05.png">

Insert mode:
<img width="1256" alt="Insert mode" src="https://cloud.githubusercontent.com/assets/7144173/24372333/8c612b20-1325-11e7-8afb-17327d21bb58.png">

Visual mode:
<img width="1256" alt="Visual mode" src="https://cloud.githubusercontent.com/assets/7144173/24372301/6b80affc-1325-11e7-8fae-89fc8cbd252a.png">

Replace mode:
<img width="1256" alt="Replace mode" src="https://cloud.githubusercontent.com/assets/7144173/24372361/a256ff18-1325-11e7-8d86-402129fd92aa.png">

Inactive mode:
<img width="1256" alt="Inactive mode" src="https://cloud.githubusercontent.com/assets/7144173/24372257/4ad4a29a-1325-11e7-93f9-e88b7f4b0e7d.png">
