### PR TITLE
Remove quotation marks around variable name

### DIFF
--- a/autoload/airline/themes/fairyfloss.vim
+++ b/autoload/airline/themes/fairyfloss.vim
@@ -39,7 +39,7 @@ let s:ctermWhite = "231"
 let s:ctermGray = "243"
 
 let g:airline#themes#fairyfloss#palette = {}
-let s:modified = { 'airline_c': [ 's:guiRose', '', 215, '', '' ] }
+let s:modified = { 'airline_c': [ s:guiRose, '', 215, '', '' ] }
 
 " Normal mode
 let s:N1 = [ s:guiSilver , s:guiLavender , s:ctermSilver , s:ctermLavender  ]


### PR DESCRIPTION
I was getting an error message saying "E254 Cannot allocate color s:guiRose" with fairyfloss theme. Looks like those quotation marks should not be here.