### PR TITLE
Use 256 colors if available for base16_tomorrow

### DIFF
--- a/autoload/airline/themes/base16_tomorrow.vim
+++ b/autoload/airline/themes/base16_tomorrow.vim
@@ -19,21 +19,30 @@ let s:gui0E = "#b294bb"
 let s:gui0F = "#a3685a"
 
 let s:cterm00 = 0
-let s:cterm01 = 0
-let s:cterm02 = 59
-let s:cterm03 = 102
-let s:cterm04 = 145
-let s:cterm05 = 188
-let s:cterm06 = 253
+let s:cterm03 = 8
+let s:cterm05 = 7
 let s:cterm07 = 15
-let s:cterm08 = 167
-let s:cterm09 = 173
-let s:cterm0A = 222
-let s:cterm0B = 143
-let s:cterm0C = 109
-let s:cterm0D = 109
-let s:cterm0E = 139
-let s:cterm0F = 131
+let s:cterm08 = 1
+let s:cterm0A = 3
+let s:cterm0B = 2
+let s:cterm0C = 6
+let s:cterm0D = 4
+let s:cterm0E = 5
+if exists('base16colorspace') && base16colorspace == "256"
+  let s:cterm01 = 18
+  let s:cterm02 = 19
+  let s:cterm04 = 20
+  let s:cterm06 = 21
+  let s:cterm09 = 16
+  let s:cterm0F = 17
+else
+  let s:cterm01 = 10
+  let s:cterm02 = 11
+  let s:cterm04 = 12
+  let s:cterm06 = 13
+  let s:cterm09 = 9
+  let s:cterm0F = 14
+endif
 
 let s:N1   = [ s:gui01, s:gui0B, s:cterm01, s:cterm0B ]
 let s:N2   = [ s:gui06, s:gui02, s:cterm06, s:cterm02 ]


### PR DESCRIPTION
The upstream base16-tomorrow-night vim colorscheme uses slightly better
colors if 256 colors are available (indicated by the 'base16colorspace'
variable). This update matches the color selection used in the upstream
colorscheme.

See base16-vim for more details:
  https://github.com/chriskempson/base16-vim/blob/master/colors/base16-tomorrow-night.vim