### PR TITLE
Add 'dark_text' option for solarized.vim

### DIFF
--- a/autoload/airline/themes/solarized.vim
+++ b/autoload/airline/themes/solarized.vim
@@ -7,6 +7,7 @@ function! airline#themes#solarized#refresh()
   let s:background           = get(g:, 'airline_solarized_bg', &background)
   let s:ansi_colors          = get(g:, 'solarized_termcolors', 16) != 256 && &t_Co >= 16 ? 1 : 0
   let s:use_green            = get(g:, 'airline_solarized_normal_green', 0)
+  let s:dark_text            = get(g:, 'airline_solarized_dark_text', 0)
   let s:dark_inactive_border = get(g:, 'airline_solarized_dark_inactive_border', 0)
   let s:tty                  = &t_Co == 8
 
@@ -60,11 +61,11 @@ function! airline#themes#solarized#refresh()
   """"""""""""""""""""""""""""""""""""""""""""""""
   " Normal mode
   if s:background == 'dark'
-    let s:N1 = [s:base3, (s:use_green ? s:green : s:base1), 'bold']
+    let s:N1 = [(s:dark_text ? s:base03 : s:base3), (s:use_green ? s:green : s:base1), 'bold']
     let s:N2 = [s:base2, (s:tty ? s:base01 : s:base00), '']
     let s:N3 = [s:base01, s:base02, '']
   else
-    let s:N1 = [s:base2, (s:use_green ? s:green : s:base00), 'bold']
+    let s:N1 = [(s:dark_text ? s:base03 : s:base2), (s:use_green ? s:green : s:base00), 'bold']
     let s:N2 = [(s:tty ? s:base01 : s:base2), s:base1, '']
     let s:N3 = [s:base1, s:base2, '']
   endif

--- a/doc/airline-themes.txt
+++ b/doc/airline-themes.txt
@@ -164,7 +164,13 @@ look more like classic powerline in normal mode. To enable it:
 >
     let g:airline_solarized_normal_green = 1
 <
+*g:airline_solarized_dark_text*
 
+Turns the text color of the outer-most sections of the statusline to be dark. 
+To enable it:
+>
+    let g:airline_solarized_dark_text = 1
+<
 *g:airline_solarized_dark_inactive_border*
 
 Changes inactive window panes to have a dark bottom border instead


### PR DESCRIPTION
Let users define whether the text should be dark or not