### PR TITLE
Fix base16 seti theme

### DIFF
--- a/autoload/airline/themes/base16_seti.vim
+++ b/autoload/airline/themes/base16_seti.vim
@@ -1,9 +1,9 @@
 " vim-airline template by chartoin (http://github.com/chartoin)
-" Base16 Seti UI by 
+" Base16 Seti UI by
 
-let g:airline#themes#base16_seti ui#palette = {}
+let g:airline#themes#base16_seti#palette = {}
 let s:gui00 = "#151718"
-let s:gui01 = "#8ec43d"
+let s:gui01 = "#282a2b"
 let s:gui02 = "#3B758C"
 let s:gui03 = "#41535B"
 let s:gui04 = "#43a5d5"
@@ -40,27 +40,27 @@ let s:cterm0F = 17
 let s:N1   = [ s:gui01, s:gui0B, s:cterm01, s:cterm0B ]
 let s:N2   = [ s:gui06, s:gui02, s:cterm06, s:cterm02 ]
 let s:N3   = [ s:gui09, s:gui01, s:cterm09, s:cterm01 ]
-let g:airline#themes#base16_seti ui#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
+let g:airline#themes#base16_seti#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
 
 let s:I1   = [ s:gui01, s:gui0D, s:cterm01, s:cterm0D ]
 let s:I2   = [ s:gui06, s:gui02, s:cterm06, s:cterm02 ]
 let s:I3   = [ s:gui09, s:gui01, s:cterm09, s:cterm01 ]
-let g:airline#themes#base16_seti ui#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
+let g:airline#themes#base16_seti#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
 
 let s:R1   = [ s:gui01, s:gui08, s:cterm01, s:cterm08 ]
 let s:R2   = [ s:gui06, s:gui02, s:cterm06, s:cterm02 ]
 let s:R3   = [ s:gui09, s:gui01, s:cterm09, s:cterm01 ]
-let g:airline#themes#base16_seti ui#palette.replace = airline#themes#generate_color_map(s:R1, s:R2, s:R3)
+let g:airline#themes#base16_seti#palette.replace = airline#themes#generate_color_map(s:R1, s:R2, s:R3)
 
 let s:V1   = [ s:gui01, s:gui0E, s:cterm01, s:cterm0E ]
 let s:V2   = [ s:gui06, s:gui02, s:cterm06, s:cterm02 ]
 let s:V3   = [ s:gui09, s:gui01, s:cterm09, s:cterm01 ]
-let g:airline#themes#base16_seti ui#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
+let g:airline#themes#base16_seti#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
 
 let s:IA1   = [ s:gui05, s:gui01, s:cterm05, s:cterm01 ]
 let s:IA2   = [ s:gui05, s:gui01, s:cterm05, s:cterm01 ]
 let s:IA3   = [ s:gui05, s:gui01, s:cterm05, s:cterm01 ]
-let g:airline#themes#base16_seti ui#palette.inactive = airline#themes#generate_color_map(s:IA1, s:IA2, s:IA3)
+let g:airline#themes#base16_seti#palette.inactive = airline#themes#generate_color_map(s:IA1, s:IA2, s:IA3)
 
 " Here we define the color map for ctrlp.  We check for the g:loaded_ctrlp
 " variable so that related functionality is loaded iff the user is using
@@ -69,8 +69,9 @@ let g:airline#themes#base16_seti ui#palette.inactive = airline#themes#generate_c
 if !get(g:, 'loaded_ctrlp', 0)
   finish
 endif
-let g:airline#themes#base16_seti ui#palette.ctrlp = airline#extensions#ctrlp#generate_color_map(
+let g:airline#themes#base16_seti#palette.ctrlp = airline#extensions#ctrlp#generate_color_map(
       \ [ s:gui07, s:gui02, s:cterm07, s:cterm02, '' ],
       \ [ s:gui07, s:gui04, s:cterm07, s:cterm04, '' ],
       \ [ s:gui05, s:gui01, s:cterm05, s:cterm01, 'bold' ])
+
 


### PR DESCRIPTION
## Overview

The base16 seti theme is currently busted due to bad naming conversions, this PR does the following:

- Fixes naming so airlines can load the theme.
- Fixes `gui01` color to [match](https://github.com/chriskempson/base16-vim/blob/master/colors/base16-seti.vim#L20) theme.