### PR TITLE
Fix minimalist.vim when tabline extension is loaded

### DIFF
--- a/autoload/airline/themes/minimalist.vim
+++ b/autoload/airline/themes/minimalist.vim
@@ -56,6 +56,9 @@ function! airline#themes#{s:theme}#refresh()
     let palette.normal.airline_warning = WI
     let palette.normal.airline_term    = TE
 
+    let palette.insert   = palette.normal
+    let palette.replace  = palette.normal
+    let palette.visual   = palette.normal
     let palette.inactive = airline#themes#generate_color_map(IA, IA, IA)
 
     if s:want_showmod


### PR DESCRIPTION
The non-normal maps may be used by other extensions. In particular,
airline#extensions#tabline#load_theme() causes errors unless they
are set.