### PR TITLE
Fix for Lucius theme to make errors more readable

### DIFF
--- a/autoload/airline/themes/lucius.vim
+++ b/autoload/airline/themes/lucius.vim
@@ -12,9 +12,13 @@ function! airline#themes#lucius#refresh()
                 \ 'airline_c': [modified_group[0], '', modified_group[2], '', '']
                 \ }
 
-    let warning_group = airline#themes#get_highlight('DiffDelete')
+    let warning_group = airline#themes#get_highlight('DiffChange')
     let g:airline#themes#lucius#palette.normal.airline_warning = warning_group
     let g:airline#themes#lucius#palette.normal_modified.airline_warning = warning_group
+
+    let error_group = airline#themes#get_highlight('DiffDelete')
+    let g:airline#themes#lucius#palette.normal.airline_error = error_group
+    let g:airline#themes#lucius#palette.normal_modified.airline_error = error_group
 
     let s:I1 = airline#themes#get_highlight('DiffAdd')
     let s:I2 = s:N2
@@ -23,6 +27,8 @@ function! airline#themes#lucius#refresh()
     let g:airline#themes#lucius#palette.insert_modified = g:airline#themes#lucius#palette.normal_modified
     let g:airline#themes#lucius#palette.insert.airline_warning = g:airline#themes#lucius#palette.normal.airline_warning
     let g:airline#themes#lucius#palette.insert_modified.airline_warning = g:airline#themes#lucius#palette.normal_modified.airline_warning
+    let g:airline#themes#lucius#palette.insert.airline_error = g:airline#themes#lucius#palette.normal.airline_error
+    let g:airline#themes#lucius#palette.insert_modified.airline_error = g:airline#themes#lucius#palette.normal_modified.airline_error
 
     let s:R1 = airline#themes#get_highlight('DiffChange')
     let s:R2 = s:N2
@@ -31,6 +37,8 @@ function! airline#themes#lucius#refresh()
     let g:airline#themes#lucius#palette.replace_modified = g:airline#themes#lucius#palette.normal_modified
     let g:airline#themes#lucius#palette.replace.airline_warning = g:airline#themes#lucius#palette.normal.airline_warning
     let g:airline#themes#lucius#palette.replace_modified.airline_warning = g:airline#themes#lucius#palette.normal_modified.airline_warning
+    let g:airline#themes#lucius#palette.replace.airline_error = g:airline#themes#lucius#palette.normal.airline_error
+    let g:airline#themes#lucius#palette.replace_modified.airline_error = g:airline#themes#lucius#palette.normal_modified.airline_error
 
     let s:V1 = airline#themes#get_highlight('Cursor')
     let s:V2 = s:N2
@@ -39,6 +47,8 @@ function! airline#themes#lucius#refresh()
     let g:airline#themes#lucius#palette.visual_modified = g:airline#themes#lucius#palette.normal_modified
     let g:airline#themes#lucius#palette.visual.airline_warning = g:airline#themes#lucius#palette.normal.airline_warning
     let g:airline#themes#lucius#palette.visual_modified.airline_warning = g:airline#themes#lucius#palette.normal_modified.airline_warning
+    let g:airline#themes#lucius#palette.visual.airline_error = g:airline#themes#lucius#palette.normal.airline_error
+    let g:airline#themes#lucius#palette.visual_modified.airline_error = g:airline#themes#lucius#palette.normal_modified.airline_error
 
     let s:IA = airline#themes#get_highlight('StatusLineNC')
     let g:airline#themes#lucius#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
@@ -59,4 +69,3 @@ function! airline#themes#lucius#refresh()
 endfunction
 
 call airline#themes#lucius#refresh()
-


### PR DESCRIPTION
The current colour for airline errors on the Lucius theme is dark red background with black text making it almost unreadable. 

Warnings are readable but slightly confusing as they use red which is often taken as an error.

So I've modified the theme to so DiffDelete is used for airline errors which, I think, makes more sense and so warnings stand out they now use DiffChange.