### PR TITLE
Make base16_shell work for all uses of base16-vim, and rename accordingly

### DIFF
--- a/autoload/airline/themes/base16_shell.vim
+++ b/autoload/airline/themes/base16_shell.vim
@@ -1,99 +1,10 @@
-let s:improved_contrast = get(g:, 'airline_base16_improved_contrast', 0)
-let s:solarized         = get(g:, 'airline_base16_solarized', 0)
+" This theme has been improved and renamed to base16_vim. The following is
+" provided for backward compatibility.
 
-" Base16 term color palette
-let s:base00_black   = 0
-let s:base08_red     = 1
-let s:base0B_green   = 2
-let s:base0A_yellow  = 3
-let s:base0D_blue    = 4
-let s:base0E_magenta = 5
-let s:base0C_cyan    = 6
-let s:base05_white   = 7
-let s:base03_brblack = 8
-let s:base09         = 16
-let s:base0F         = 17
-let s:base01         = 18
-let s:base02         = 19
-let s:base04         = 20
-let s:base06         = 21
+function! airline#themes#base16_shell#refresh()
+  call airline#themes#base16_vim#refresh()
+  let g:airline#themes#base16_shell#palette
+        \ = g:airline#themes#base16_vim#palette
+endfunction
 
-" Gui color palette
-let s:gui_dark_gray       = '#202020'
-let s:gui_med_gray_lo     = '#3a3a3a'
-let s:gui_med_gray_hi     = '#303030'
-let s:gui_light_gray      = '#505050'
-let s:gui_lightlight_gray = '#8A8A8A'
-let s:gui_green           = '#99cc99'
-let s:gui_blue            = '#6a9fb5'
-let s:gui_purple          = '#aa759f'
-let s:gui_orange          = '#d28445'
-let s:gui_red             = '#ac4142'
-let s:gui_pink            = '#d7afd7'
-
-let g:airline#themes#base16_shell#palette = {}
-
-" Normal mode
-let s:N1 = [s:gui_dark_gray, s:gui_green, s:base00_black, s:base0B_green]
-let s:N2 = [s:gui_light_gray, s:gui_med_gray_lo, s:base04, s:base02]
-let s:N3 = [s:gui_green, s:gui_med_gray_hi, s:base0B_green, s:base01]
-
-if s:improved_contrast
-    let s:N2 = [s:gui_lightlight_gray, s:gui_med_gray_lo, s:base05_white, s:base02]
-endif
-
-if s:solarized
-    let s:N1 = [s:gui_dark_gray, s:gui_green, s:base01, s:base04]
-    let s:N2 = [s:gui_light_gray, s:gui_med_gray_lo, s:base00_black, s:base02]
-    let s:N3 = [s:gui_green, s:gui_med_gray_hi, s:base04, s:base01]
-endif
-
-let g:airline#themes#base16_shell#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
-let g:airline#themes#base16_shell#palette.normal_modified = {
-            \ 'airline_c': [s:gui_orange, s:gui_med_gray_hi, s:base09, s:base01, ''],
-            \ }
-
-" Insert mode
-let s:I1 = [s:gui_med_gray_hi, s:gui_blue, s:base01, s:base0D_blue]
-let s:I3 = [s:gui_blue, s:gui_med_gray_hi, s:base0D_blue, s:base01]
-let g:airline#themes#base16_shell#palette.insert = airline#themes#generate_color_map(s:I1, s:N2, s:I3)
-
-if s:solarized
-    let s:I1 = [s:gui_med_gray_hi, s:gui_blue, s:base01, s:base0A_yellow]
-    let g:airline#themes#base16_shell#palette.insert = airline#themes#generate_color_map(s:I1, s:N2, s:N3)
-endif
-
-let g:airline#themes#base16_shell#palette.insert_modified = copy(g:airline#themes#base16_shell#palette.normal_modified)
-
-" Replace mode
-let s:R1 = [s:gui_dark_gray, s:gui_red, s:base01, s:base08_red]
-let s:R3 = [s:gui_red, s:gui_med_gray_hi, s:base08_red, s:base01]
-let g:airline#themes#base16_shell#palette.replace = airline#themes#generate_color_map(s:R1, s:N2, s:R3)
-
-if s:solarized
-    let s:R1 = [s:gui_dark_gray, s:gui_red, s:base01, s:base09]
-    let g:airline#themes#base16_shell#palette.replace = airline#themes#generate_color_map(s:R1, s:N2, s:N3)
-endif
-
-let g:airline#themes#base16_shell#palette.replace_modified = copy(g:airline#themes#base16_shell#palette.normal_modified)
-
-" Visual mode
-let s:V1 = [s:gui_dark_gray, s:gui_pink, s:base01, s:base0E_magenta]
-let s:V3 = [s:gui_pink, s:gui_med_gray_hi, s:base0E_magenta, s:base01]
-let g:airline#themes#base16_shell#palette.visual = airline#themes#generate_color_map(s:V1, s:N2, s:V3)
-
-if s:solarized
-  let s:V1 = [s:gui_dark_gray, s:gui_pink, s:base01, s:base0F]
-  let g:airline#themes#base16_shell#palette.visual = airline#themes#generate_color_map(s:V1, s:N2, s:N3)
-endif
-
-" Inactive window
-if s:improved_contrast
-    let s:IA = [s:gui_dark_gray, s:gui_med_gray_hi, s:base04, s:base01, '']
-else
-    let s:IA = [s:gui_dark_gray, s:gui_med_gray_hi, s:base03_brblack, s:base01, '']
-endif
-let g:airline#themes#base16_shell#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
-let g:airline#themes#base16_shell#palette.inactive_modified = {
-            \ 'airline_c': [s:gui_orange, '', s:base09, '', ''],
-            \ }
+call airline#themes#base16_shell#refresh()

--- a/autoload/airline/themes/base16_vim.vim
+++ b/autoload/airline/themes/base16_vim.vim
@@ -1,0 +1,172 @@
+let g:airline#themes#base16_vim#palette = {}
+
+function! airline#themes#base16_vim#refresh()
+  let s:improved_contrast = get(g:, 'airline_base16_improved_contrast', 0)
+  let s:monotone = get(g:, 'airline_base16_monotone', 0)
+        \ || get(g:, 'airline_base16_solarized', 0)
+
+  if exists('g:base16_gui00')
+    " base16-vim provides values that we can load dynamically
+
+    " Base16 term color palette
+    let s:base00 = g:base16_cterm00  " black
+    let s:base01 = g:base16_cterm01
+    let s:base02 = g:base16_cterm02
+    let s:base03 = g:base16_cterm03  " brblack
+    let s:base04 = g:base16_cterm04
+    let s:base05 = g:base16_cterm05  " white
+    let s:base06 = g:base16_cterm06
+    let s:base07 = g:base16_cterm07
+    let s:base08 = g:base16_cterm08  " red
+    let s:base09 = g:base16_cterm09
+    let s:base0A = g:base16_cterm0A  " yellow
+    let s:base0B = g:base16_cterm0B  " green
+    let s:base0C = g:base16_cterm0C  " cyan
+    let s:base0D = g:base16_cterm0D  " blue
+    let s:base0E = g:base16_cterm0E  " magenta
+    let s:base0F = g:base16_cterm0F
+
+    " Gui color palette
+    let s:gui00 = "#" . g:base16_gui00
+    let s:gui01 = "#" . g:base16_gui01
+    let s:gui02 = "#" . g:base16_gui02
+    let s:gui03 = "#" . g:base16_gui03
+    let s:gui04 = "#" . g:base16_gui04
+    let s:gui05 = "#" . g:base16_gui05
+    let s:gui06 = "#" . g:base16_gui06
+    let s:gui07 = "#" . g:base16_gui07
+    let s:gui08 = "#" . g:base16_gui08
+    let s:gui09 = "#" . g:base16_gui09
+    let s:gui0A = "#" . g:base16_gui0A
+    let s:gui0B = "#" . g:base16_gui0B
+    let s:gui0C = "#" . g:base16_gui0C
+    let s:gui0D = "#" . g:base16_gui0D
+    let s:gui0E = "#" . g:base16_gui0E
+    let s:gui0F = "#" . g:base16_gui0F
+  else
+    " Fallback: term colors should still be correct, but gui colors must be
+    " hardcoded to a particular scheme.
+
+    " Base16 term color palette
+    let s:base00 = "00"  " black
+    let s:base03 = "08"  " brblack
+    let s:base05 = "07"  " white
+    let s:base07 = "15"
+    let s:base08 = "01"  " red
+    let s:base0A = "03"  " yellow
+    let s:base0B = "02"  " green
+    let s:base0C = "06"  " cyan
+    let s:base0D = "04"  " blue
+    let s:base0E = "05"  " magenta
+    if exists('g:base16colorspace') && g:base16colorspace == "256"
+      let s:base01 = "18"
+      let s:base02 = "19"
+      let s:base04 = "20"
+      let s:base06 = "21"
+      let s:base09 = "16"
+      let s:base0F = "17"
+    else
+      let s:base01 = "10"
+      let s:base02 = "11"
+      let s:base04 = "12"
+      let s:base06 = "13"
+      let s:base09 = "09"
+      let s:base0F = "14"
+    endif
+
+    " Gui color palette (base16-default-dark)
+    let s:gui00 = "#181818"
+    let s:gui01 = "#282828"
+    let s:gui02 = "#383838"
+    let s:gui03 = "#585858"
+    let s:gui04 = "#b8b8b8"
+    let s:gui05 = "#d8d8d8"
+    let s:gui06 = "#e8e8e8"
+    let s:gui07 = "#f8f8f8"
+    let s:gui08 = "#ab4642"
+    let s:gui09 = "#dc9656"
+    let s:gui0A = "#f7ca88"
+    let s:gui0B = "#a1b56c"
+    let s:gui0C = "#86c1b9"
+    let s:gui0D = "#7cafc2"
+    let s:gui0E = "#ba8baf"
+    let s:gui0F = "#a16946"
+  endif
+
+  " Normal mode
+  let s:N1 = [s:gui00, s:gui0B, s:base00, s:base0B]
+  let s:N2 = [s:gui04, s:gui02, s:base04, s:base02]
+  let s:N3 = [s:gui0B, s:gui01, s:base0B, s:base01]
+
+  if s:improved_contrast
+      let s:N2 = [s:gui05, s:gui02, s:base05, s:base02]
+  endif
+
+  if s:monotone
+    let s:N1 = [s:gui01, s:gui04, s:base01, s:base04]
+    let s:N2 = [s:gui00, s:gui02, s:base00, s:base02]
+    let s:N3 = [s:gui04, s:gui01, s:base04, s:base01]
+  endif
+
+  let g:airline#themes#base16_vim#palette.normal
+        \ = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
+  let g:airline#themes#base16_vim#palette.normal_modified = {
+        \ 'airline_c': [s:gui09, s:gui01, s:base09, s:base01, ''],
+        \ }
+
+  " Insert mode
+  let s:I1 = [s:gui01, s:gui0D, s:base01, s:base0D]
+  let s:I3 = [s:gui0D, s:gui01, s:base0D, s:base01]
+  let g:airline#themes#base16_vim#palette.insert
+        \ = airline#themes#generate_color_map(s:I1, s:N2, s:I3)
+
+  if s:monotone
+    let s:I1 = [s:gui01, s:gui0A, s:base01, s:base0A]
+    let g:airline#themes#base16_vim#palette.insert
+          \ = airline#themes#generate_color_map(s:I1, s:N2, s:N3)
+  endif
+
+  let g:airline#themes#base16_vim#palette.insert_modified
+        \ = copy(g:airline#themes#base16_vim#palette.normal_modified)
+
+  " Replace mode
+  let s:R1 = [s:gui01, s:gui08, s:base01, s:base08]
+  let s:R3 = [s:gui08, s:gui01, s:base08, s:base01]
+  let g:airline#themes#base16_vim#palette.replace
+        \ = airline#themes#generate_color_map(s:R1, s:N2, s:R3)
+
+  if s:monotone
+    let s:R1 = [s:gui01, s:gui09, s:base01, s:base09]
+    let g:airline#themes#base16_vim#palette.replace
+          \ = airline#themes#generate_color_map(s:R1, s:N2, s:N3)
+  endif
+
+  let g:airline#themes#base16_vim#palette.replace_modified
+        \ = copy(g:airline#themes#base16_vim#palette.normal_modified)
+
+  " Visual mode
+  let s:V1 = [s:gui01, s:gui0E, s:base01, s:base0E]
+  let s:V3 = [s:gui0E, s:gui01, s:base0E, s:base01]
+  let g:airline#themes#base16_vim#palette.visual
+        \ = airline#themes#generate_color_map(s:V1, s:N2, s:V3)
+
+  if s:monotone
+    let s:V1 = [s:gui01, s:gui0F, s:base01, s:base0F]
+    let g:airline#themes#base16_vim#palette.visual
+          \ = airline#themes#generate_color_map(s:V1, s:N2, s:N3)
+  endif
+
+  " Inactive window
+  if s:improved_contrast
+    let s:IA = [s:gui04, s:gui01, s:base04, s:base01, '']
+  else
+    let s:IA = [s:gui03, s:gui01, s:base03, s:base01, '']
+  endif
+  let g:airline#themes#base16_vim#palette.inactive
+        \ = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
+  let g:airline#themes#base16_vim#palette.inactive_modified = {
+        \ 'airline_c': [s:gui09, '', s:base09, '', ''],
+        \ }
+endfunction
+
+call airline#themes#base16_vim#refresh()

--- a/doc/airline-themes.txt
+++ b/doc/airline-themes.txt
@@ -33,6 +33,7 @@ Currently this repository contains the following themes:
     * badcat
     * badwolf
     * base16 (|airline-theme-base16|)
+    * base16_vim (|airline-theme-base16_vim|)
     * base16_shell (|airline-theme-base16_shell|)
     * base16_3024
     * base16_apathy
@@ -65,7 +66,7 @@ Currently this repository contains the following themes:
     * base16_monokai
     * base16_nord
     * base16_ocean
-    * base16_oceanicnext (|airline-theme-base16-oceanicnext|)
+    * base16_oceanicnext
     * base16_paraiso
     * base16_pop
     * base16_railscasts
@@ -74,8 +75,9 @@ Currently this repository contains the following themes:
     * base16_solarized
     * base16_spacemacs
     * base16_summerfruit
-    * base16_tomorrow (|airline-theme-base16_tomorrow|)
+    * base16_tomorrow
     * base16_twilight
+    * base16_vim
     * base16color
     * behelit
     * biogoo
@@ -141,49 +143,53 @@ To define a theme to be used by vim-airline you can set the variable
 g:airline_theme in your |.vimrc|  like this: >
     :let g:airline_theme='dark'
 <
-*airline-theme-base16*
+*airline-theme-base16_vim*
+*airline-theme-base16_shell*
 ------------------------------------------------------------------------------
-Base16 is a popular theme from Chris Kempson
-(https://github.com/chriskempson/base16-vim)
+Base16 is an extensive collection of colorschemes built on a common
+architecture by Chris Kempson (http://chriskempson.com/projects/base16/). The
+base16_vim airline theme integrates with the base16-vim plugin
+(https://github.com/chriskempson/base16-vim) to match the currently selected
+colorscheme. This works with all modes of using base16-vim: running vim in
+a terminal configured with base16-shell
+(https://github.com/chriskempson/base16-shell), running vim with
+'termguicolors' set, or running gvim.
 
-The default theme is base16, all other base16-themes have been generated and
-might not support all options.
+The alias base16_shell is provided for backward compatibility.
+
+This theme provides two options:
 
                                         *g:airline_base16_improved_contrast*
 
-Improves the contrast for the inactive statusline. To enable it: >
+Improve the contrast for the inactive statusline. >
     let g:airline_base16_improved_contrast = 1
-<
-                                                *airline#themes#base16#constant*
-
-Uses a predefined colorpalette for defining the colors, instead of guessing
-the values from other highlight groups. To enable it: >
-    let g:airline#themes#base16#constant = 1
-<
-                                                  *airline-theme-base16-shell*
-
-base16_shell theme for vim-airline matches your active Base16 Shell theme.
-
-It should be used in combination with Base16 Shell, which sets the correct
-colors in the terminal: (https://github.com/chriskempson/base16-shell). The
-colors used in this theme are within the 21 term colors set by Base16 Shell.
-The theme supports 2 options described below.
-
+Default: 0
+                                                *g:airline_base16_monotone*
                                                 *g:airline_base16_solarized*
 
-Adjusts the colors to match base16_solarized shell theme. You may also try to
-use it with other Base16 Shell themes. To enable it: >
-    let g:airline_base16_solarized = 1
-<
-                                                 *airline-theme-base16-tomorrow*
-                                                *airline-theme-base16-oceanicnext*
+Adjust the theme for a more monotonic look. This option is designed with the
+base16-solarized-(light|dark) colorschemes in mind, but work well with the
+other base16 colorshemes as well. >
+    let g:airline_base16_monotone = 1
+or, >
+    let g:airline_base16_solarized = 1  " retained for backward compatibility
+Default: 0
 
-base16 theme for vim-airline matches your active Base16 colorscheme.
+*airline-theme-base16*
+------------------------------------------------------------------------------
+This theme matches base16 colorschemes by extracting colors from highlight
+groups, and also provides a static option.
 
-Allow 256 color use of the base16 theme. Without this setting
-the theme may look incorrect in 256 color mode. To enable it: >
-    let base16colorspace = 256
-<
+                                                *airline#themes#base16#constant*
+
+Use a predefined palette instead of guessing values from highlight groups. To
+enable: >
+    let g:airline#themes#base16#constant = 1
+Default: 0
+
+A number of static themes that match particular base16 colorschemes are also
+available, see |airline-themes-list|.
+
 *airline-theme-dark_minimal*
 ------------------------------------------------------------------------------
 This is a copy of the dark.vim theme, however it does not change colors in
@@ -226,17 +232,6 @@ be shown in a nice orange. >
 <
 *airline-theme-solarized*
 ------------------------------------------------------------------------------
-                                                        *g:solarized_base16*
-
-Base16 has a Solarized theme with the usual colors, but mapped in the
-terminal differently.  The main difference is that the bright colors,
-Ansi 9-15, are left the same as their Ansi 1-7 counterparts.  The
-remaining solarized colors are mapped into higher indexes by using
-Base16 Shell. To enable it: >
-    let g:solarized_base16 = 1
-<
-See also https://github.com/blueyed/vim-colors-solarized/commit/92f2f994.
-
                                                 *g:airline_solarized_normal_green*
 
 Turns the outer-most section of the statusline Solarized green, making it
@@ -255,6 +250,17 @@ Changes inactive window panes to have a dark bottom border instead
 of light by default. To enable it: >
     let g:airline_solarized_dark_inactive_border = 1
 <
+                                                        *g:solarized_base16*
+
+Base16 has a Solarized theme with the usual colors, but mapped in the
+terminal differently.  The main difference is that the bright colors,
+Ansi 9-15, are left the same as their Ansi 1-7 counterparts.  The
+remaining solarized colors are mapped into higher indexes by using
+Base16 Shell. To enable it: >
+    let g:solarized_base16 = 1
+<
+See also https://github.com/blueyed/vim-colors-solarized/commit/92f2f994.
+
 *airline-theme-zenburn*
 ------------------------------------------------------------------------------
                                                        *g:zenburn_high_Contrast*


### PR DESCRIPTION
The base16_shell theme adapts to match the selected base16-vim colorscheme, but only if base16-shell is used to configure the underlying terminal. This restriction is unnecessary: base16-vim can be used without base16-shell (either in gvim, or with termguicolors set), and the color palette is always exposed. This PR makes the theme work in all contexts, and renames it accordingly to base16_vim. Backward compatibility is retained by keeping base16_shell as an alias for base16_vim.

I also renamed the `g:airline_base16_solarized` option to `g:airline_base16_monotone`, since it has nothing to do with solarized in principle. (I actually prefer it for most, if not all, base16 themes.) Here, too, backward compatibility is retained.