### PR TITLE
Adding the setup for warnings and errors in base16_atelierdune

### DIFF
--- a/autoload/airline/themes/base16_atelierdune.vim
+++ b/autoload/airline/themes/base16_atelierdune.vim
@@ -1,22 +1,27 @@
 " vim-airline template by chartoin (http://github.com/chartoin)
 " Base 16 Atelier Dune Scheme by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune)
 let g:airline#themes#base16_atelierdune#palette = {}
-let s:gui00 = '#20201d'
-let s:gui01 = '#292824'
-let s:gui02 = '#6e6b5e'
-let s:gui03 = '#7d7a68'
-let s:gui04 = '#999580'
-let s:gui05 = '#a6a28c'
-let s:gui06 = '#e8e4cf'
-let s:gui07 = '#fefbec'
-let s:gui08 = '#d73737'
-let s:gui09 = '#b65611'
-let s:gui0A = '#cfb017'
-let s:gui0B = '#60ac39'
-let s:gui0C = '#1fad83'
-let s:gui0D = '#6684e1'
-let s:gui0E = '#b854d4'
-let s:gui0F = '#d43552'
+
+let g:airline#themes#base16_atelierdune#palette.accents = {
+      \ 'red': [ '#ffffff' , '' , 231 , '' , '' ],
+      \ }
+
+let s:gui00 = "#20201d"
+let s:gui01 = "#292824"
+let s:gui02 = "#6e6b5e"
+let s:gui03 = "#7d7a68"
+let s:gui04 = "#999580"
+let s:gui05 = "#a6a28c"
+let s:gui06 = "#e8e4cf"
+let s:gui07 = "#fefbec"
+let s:gui08 = "#d73737"
+let s:gui09 = "#b65611"
+let s:gui0A = "#cfb017"
+let s:gui0B = "#60ac39"
+let s:gui0C = "#1fad83"
+let s:gui0D = "#6684e1"
+let s:gui0E = "#b854d4"
+let s:gui0F = "#d43552"
 
 let s:cterm00 = 0
 let s:cterm01 = 0
@@ -27,13 +32,13 @@ let s:cterm05 = 144
 let s:cterm06 = 188
 let s:cterm07 = 15
 let s:cterm08 = 167
-let s:cterm09 = 130
+let s:cterm09 = 182
 let s:cterm0A = 178
 let s:cterm0B = 71
 let s:cterm0C = 36
 let s:cterm0D = 68
 let s:cterm0E = 134
-let s:cterm0F = 167
+let s:cterm0F = 182
 
 let s:N1   = [ s:gui01, s:gui0B, s:cterm01, s:cterm0B ]
 let s:N2   = [ s:gui06, s:gui02, s:cterm06, s:cterm02 ]
@@ -60,6 +65,20 @@ let s:IA2   = [ s:gui05, s:gui01, s:cterm05, s:cterm01 ]
 let s:IA3   = [ s:gui05, s:gui01, s:cterm05, s:cterm01 ]
 let g:airline#themes#base16_atelierdune#palette.inactive = airline#themes#generate_color_map(s:IA1, s:IA2, s:IA3)
 
+" Warning info
+let s:WARNING = [ s:gui01, s:gui0A, s:cterm0C, s:cterm06 ]
+let s:ERROR = [ s:gui07, s:gui08, s:cterm07, s:cterm08 ]
+
+let g:airline#themes#base16_atelierdune#palette.normal.airline_warning = s:WARNING
+let g:airline#themes#base16_atelierdune#palette.insert.airline_warning = s:WARNING
+let g:airline#themes#base16_atelierdune#palette.visual.airline_warning = s:WARNING
+let g:airline#themes#base16_atelierdune#palette.replace.airline_warning = s:WARNING
+
+let g:airline#themes#base16_atelierdune#palette.normal.airline_error = s:ERROR
+let g:airline#themes#base16_atelierdune#palette.insert.airline_error = s:ERROR
+let g:airline#themes#base16_atelierdune#palette.visual.airline_error = s:ERROR
+let g:airline#themes#base16_atelierdune#palette.replace.airline_error = s:ERROR
+
 " Here we define the color map for ctrlp.  We check for the g:loaded_ctrlp
 " variable so that related functionality is loaded iff the user is using
 " ctrlp. Note that this is optional, and if you do not define ctrlp colors
@@ -71,9 +90,3 @@ let g:airline#themes#base16_atelierdune#palette.ctrlp = airline#extensions#ctrlp
       \ [ s:gui07, s:gui02, s:cterm07, s:cterm02, '' ],
       \ [ s:gui07, s:gui04, s:cterm07, s:cterm04, '' ],
       \ [ s:gui05, s:gui01, s:cterm05, s:cterm01, 'bold' ])
-
-for mode in keys(g:airline#themes#fruit_punch#palette)
-  if mode == 'accents'
-    continue
-  endif
-endfor


### PR DESCRIPTION
As of now, only a subset of airline themes set up the color palette for warnings and errors. This will make displaying diagnostic info quite ugly from ALE and coc (see issue #173). This PR adds the setup for warnings and erros only for base16 aterlier dune as a demo. 

<img width="2113" alt="Screen Shot 2019-05-06 at 11 56 48 AM" src="https://user-images.githubusercontent.com/15823053/57237833-0cdda100-6ff6-11e9-9ebc-e465755e17b5.png">
