### PR TITLE
Add 'enable_command_color' option for solarized.vim

### DIFF
--- a/autoload/airline/themes/solarized.vim
+++ b/autoload/airline/themes/solarized.vim
@@ -9,6 +9,7 @@ function! airline#themes#solarized#refresh()
   let s:use_green            = get(g:, 'airline_solarized_normal_green', 0)
   let s:dark_text            = get(g:, 'airline_solarized_dark_text', 0)
   let s:dark_inactive_border = get(g:, 'airline_solarized_dark_inactive_border', 0)
+  let s:enable_command_color = get(g:, 'airline_solarized_enable_command_color', 0)
   let s:tty                  = &t_Co == 8
 
   """"""""""""""""""""""""""""""""""""""""""""""""
@@ -99,6 +100,13 @@ function! airline#themes#solarized#refresh()
   let s:R3 = s:N3
   let s:RM = s:NM
   let s:RF = s:NF
+
+  " Command mode
+  let s:C1 = [s:N1[0], s:violet, '']
+  let s:C2 = s:N2
+  let s:C3 = s:N3
+  let s:CF = s:NF
+  let s:CM = s:NM
 
   " Inactive, according to VertSplit in solarized
   " (bg dark: base00; bg light: base0)
@@ -194,6 +202,23 @@ function! airline#themes#solarized#refresh()
 
   let g:airline#themes#solarized#palette.replace_modified.airline_warning =
         \ g:airline#themes#solarized#palette.normal.airline_warning
+
+  let g:airline#themes#solarized#palette.replace_modified.airline_warning =
+        \ g:airline#themes#solarized#palette.normal.airline_warning
+
+  if s:enable_command_color
+    let g:airline#themes#solarized#palette.commandline = airline#themes#generate_color_map(
+          \ [s:C1[0].g, s:C1[1].g, s:C1[0].t, s:C1[1].t, s:C1[2]],
+          \ [s:C2[0].g, s:C2[1].g, s:C2[0].t, s:C2[1].t, s:C2[2]],
+          \ [s:C3[0].g, s:C3[1].g, s:C3[0].t, s:C3[1].t, s:C3[2]])
+
+    let g:airline#themes#solarized#palette.commandline.airline_warning =
+          \ g:airline#themes#solarized#palette.normal.airline_warning
+
+    let g:airline#themes#solarized#palette.commandline_modified = {
+          \ 'airline_c': [s:RM[0].g, s:RM[1].g,
+          \ s:RM[0].t, s:RM[1].t, s:RM[2]]}
+  endif
 
   let g:airline#themes#solarized#palette.tabline = {}
 

--- a/doc/airline-themes.txt
+++ b/doc/airline-themes.txt
@@ -256,6 +256,11 @@ Changes inactive window panes to have a dark bottom border instead
 of light by default. To enable it: >
     let g:airline_solarized_dark_inactive_border = 1
 <
+                                        *g:airline_solarized_enable_command_color*
+
+In command mode, set the status line to its own color (violet). To enable it: >
+    let airline_solarized_enable_command_color = 1
+<
                                                         *g:solarized_base16*
 
 Base16 has a Solarized theme with the usual colors, but mapped in the


### PR DESCRIPTION
Allow users to enable a different color for the status line in command
mode.

<img width="843" alt="Screen Shot 2019-08-10 at 4 50 05 PM" src="https://user-images.githubusercontent.com/3442461/62819352-0c254f80-bb8f-11e9-9165-fd8b8fd81aec.png">
