### PR TITLE
Add 'g:airline_solarized_dark_inactive_background' option for solarized.vim

### DIFF
--- a/autoload/airline/themes/solarized.vim
+++ b/autoload/airline/themes/solarized.vim
@@ -7,6 +7,7 @@ function! airline#themes#solarized#refresh()
   let s:background           = get(g:, 'airline_solarized_bg', &background)
   let s:ansi_colors          = get(g:, 'solarized_termcolors', 16) != 256 && &t_Co >= 16 ? 1 : 0
   let s:use_green            = get(g:, 'airline_solarized_normal_green', 0)
+  let s:dark_inactive_tab    = get(g:, 'airline_solarized_dark_inactive_background', 0)
   let s:dark_text            = get(g:, 'airline_solarized_dark_text', 0)
   let s:dark_inactive_border = get(g:, 'airline_solarized_dark_inactive_border', 0)
   let s:tty                  = &t_Co == 8
@@ -198,7 +199,7 @@ function! airline#themes#solarized#refresh()
   let g:airline#themes#solarized#palette.tabline = {}
 
   let g:airline#themes#solarized#palette.tabline.airline_tab = [
-        \ s:I2[0].g, s:I2[1].g, s:I2[0].t, s:I2[1].t, s:I2[2]]
+        \ s:I2[0].g, s:I2[1].g, s:I2[0].t, (s:dark_inactive_tab ? s:I3[0].t : s:I2[1].t), s:I2[2]]
 
   let g:airline#themes#solarized#palette.tabline.airline_tabtype = [
         \ s:N2[0].g, s:N2[1].g, s:N2[0].t, s:N2[1].t, s:N2[2]]

--- a/doc/airline-themes.txt
+++ b/doc/airline-themes.txt
@@ -244,6 +244,12 @@ Turns the outer-most section of the statusline Solarized green, making it
 look more like classic powerline in normal mode. To enable it: >
     let g:airline_solarized_normal_green = 1
 <
+                                                *airline_solarized_dark_inactive_background*
+
+For buffer(s) in the tabline that are displayed in an inactive window pane,
+use a darker background for the buffer display in the tabline. To enable it: >
+    let g:airline_solarized_dark_inactive_background = 1
+<
                                                 *g:airline_solarized_dark_text*
 
 Turns the text color of the outer-most sections of the statusline to be dark.


### PR DESCRIPTION
Increases contrast to make it easier to distinguish between active and inactive buffers.

Default:
<img width="288" alt="Screen Shot 2019-08-10 at 7 31 29 PM" src="https://user-images.githubusercontent.com/3442461/62821099-3c2e1c00-bbaa-11e9-818e-e2c3dff4ea47.png">
Darker:
<img width="284" alt="Screen Shot 2019-08-10 at 7 29 56 PM" src="https://user-images.githubusercontent.com/3442461/62821116-713a6e80-bbaa-11e9-825a-f32cb63ed728.png">

