### PR TITLE
add check to vim version

### DIFF
--- a/plugin/airline-themes.vim
+++ b/plugin/airline-themes.vim
@@ -1,7 +1,9 @@
-" MIT License. Copyright (c) 2013-2016 Bailey Ling & Contributors.
+" MIT License. Copyright (c) 2013-2019 Bailey Ling & Contributors.
 " vim: et ts=2 sts=2 sw=2
 
-if (exists('g:loaded_airline_themes') && g:loaded_airline_themes)
+scriptencoding utf-8
+
+if &cp || v:version < 702 || (exists('g:loaded_airline_themes') && g:loaded_airline_themes)
   finish
 endif
 let g:loaded_airline_themes = 1


### PR DESCRIPTION
Hello!

I updated it with reference to the script in the plugin directory of vim-airline.

This prevents `v:version` below `702` from being loaded in the same way as vim-airline.

## Like this

> https://github.com/vim-airline/vim-airline/pull/5
> https://github.com/vim-airline/vim-airline/pull/5/commits/abd286ca83ae99a801e8cee8ef1bb3756cee4311

At the same time, the copyright was updated.
Please confirm this Pull Request.