### PR TITLE
[fix] ctrlp's colorscheme

### DIFF
--- a/autoload/airline/themes/alduin.vim
+++ b/autoload/airline/themes/alduin.vim
@@ -85,9 +85,13 @@ let g:airline#themes#alduin#palette.inactive_modified = s:modified
 
 " CtrlP
 if !get(g:, 'loaded_ctrlp', 0)
-    finish
+  finish
 endif
 
 let s:CP1 = [s:guiWhite, s:gui01, s:ctermWhite, s:cterm01]
 let s:CP2 = [s:guiWhite, s:gui03, s:ctermWhite, s:cterm01]
 let s:CP3 = [s:guiWhite, s:gui0D, s:ctermWhite, s:cterm0D]
+let g:airline#themes#alduin#palette.ctrlp = airline#extensions#ctrlp#generate_color_map(
+      \ s:CP1,
+      \ s:CP2,
+      \ s:CP3)


### PR DESCRIPTION
Hi, Christian.
I fixed alduin's colorscheme a bit about ctrlp's colorscheme.
Could you check this Pull Request?

## screenshot

### bofore

<img width="1440" alt="スクリーンショット 2020-02-07 4 04 33" src="https://user-images.githubusercontent.com/36619465/73970137-f9ce7780-495f-11ea-9b62-3963d0c94407.png">

### after

<img width="1440" alt="スクリーンショット 2020-02-07 4 03 11" src="https://user-images.githubusercontent.com/36619465/73970160-0357df80-4960-11ea-9938-d1ea5eb2e7ce.png">

