### PR TITLE
[fix] github-actions's url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vim-airline-themes [![Build Status](https://travis-ci.org/vim-airline/vim-airline-themes.svg?branch=master)](https://travis-ci.org/vim-airline/vim-airline-themes) [![reviewdog](https://github.com/vim-airline/vim-airline-themes/workflows/reviewdog/badge.svg?branch=master)](https://github.com/vim-airline/vim-airline-themes/actions?query=workflow%3Areviewdog+event%3Apush+branch%3Amaster)
+# vim-airline-themes [![Build Status](https://travis-ci.org/vim-airline/vim-airline-themes.svg?branch=master)](https://travis-ci.org/vim-airline/vim-airline-themes) [![reviewdog](https://github.com/vim-airline/vim-airline-themes/workflows/reviewdog/badge.svg?branch=master&event=push)](https://github.com/vim-airline/vim-airline-themes/actions?query=workflow%3Areviewdog+event%3Apush+branch%3Amaster)
 
 This is the official theme repository for [vim-airline][11]
 


### PR DESCRIPTION
Hello, Christian.
I changed github-actions badge 's url a bit.
I changed to show in README only when pushed to master branch.

## Reference

https://github.com/vim-airline/vim-airline/pull/2092