### PR TITLE
Atomic theme: don't define section z

### DIFF
--- a/autoload/airline/themes/atomic.vim
+++ b/autoload/airline/themes/atomic.vim
@@ -7,7 +7,7 @@
 "
 "----------------------------------------------------------------
 "  Theme   : Atomic
-"  Version : 2.0.0
+"  Version : 2.1.0
 "  License : MIT
 "  Author  : Gerard Bajona
 "  URL     : https://github.com/gerardbm/atomic
@@ -71,8 +71,6 @@ function! airline#themes#atomic#refresh()
 	" Settings
 	let g:airline_symbols.paste = 'Ξ'
 	let g:airline_symbols.spell = 'S'
-	let g:airline_section_z = airline#section#create(['--%1p%%-- ',
-		\ '%#__accent_bold#%l%#__restore__#', ':%c'])
 
 endfunction
 


### PR DESCRIPTION
I'm the author of the theme Atomic. The definition of a section is not theme territory, it should be in Vim config files. That's the reason I'm updating the theme to the version 2.1.0. Therefore, this fix will allow users to create custom section z in their config files.