### PR TITLE
added power support arch ppc64le on yml file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,40 @@ matrix:
     - os: osx
       env:
         - VIM_VERSION=8.2.1000
-
+        # added power support arch ppc64le.
+        
+    - os: linux
+      arch: ppc64le
+      env:
+        - VIM_VERSION=8.0.0000
+    - os: linux
+      arch: ppc64le
+      env:
+        - VIM_VERSION=8.1.0000
+    - os: linux
+      arh: ppc64le
+      env:
+        - VIM_VERSION=8.2.0000
+    - os: linux
+      arch: ppc64le
+      env:
+        - VIM_VERSION=8.2.1000
+    - os: osx
+      arch: ppc64le
+      env:
+        - VIM_VERSION=8.0.0000
+    - os: osx
+      arch: ppc64le
+      env:
+        - VIM_VERSION=8.1.0000
+    - os: osx
+      arch: ppc64le
+      env:
+        - VIM_VERSION=8.2.0000
+    - os: osx
+      arch: ppc64le
+      env:
+        - VIM_VERSION=8.2.1000
 before_install:
   - curl https://raw.githubusercontent.com/kana/vim-version-manager/master/bin/vvm | python - setup; true
   - source ~/.vvm/etc/login


### PR DESCRIPTION
Hi team, 
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.
continuous integration build has passed without any failures after adding power support arch.kindly check and close this component.

