### PR TITLE
add onedark terminal colors

### DIFF
--- a/autoload/airline/themes/onedark.vim
+++ b/autoload/airline/themes/onedark.vim
@@ -67,6 +67,17 @@ function! airline#themes#onedark#refresh()
   let g:airline#themes#onedark#palette.inactive_modified = {
         \ 'airline_c': [ group[0], '', group[2], '', '' ]
         \ }
+  
+  " Match :term colors
+  let g:airline#themes#onedark#palette.terminal =
+      \ airline#themes#generate_color_map(s:I1, s:I2, s:I3)
+  let g:airline#themes#onedark#palette.terminal.airline_term = s:I3
+  let g:airline#themes#onedark#palette.normal.airline_term = s:N3
+  let g:airline#themes#onedark#palette.normal_modified.airline_term = s:N3
+  let g:airline#themes#onedark#palette.visual.airline_term = s:V3
+  let g:airline#themes#onedark#palette.visual_modified.airline_term = s:V3
+  let g:airline#themes#onedark#palette.inactive.airline_term = s:IA2
+  let g:airline#themes#onedark#palette.inactive_modified.airline_term = s:IA2
 
   " Warning/Error styling code from vim-airline's ["base16" theme](https://github.com/vim-airline/vim-airline-themes/blob/master/autoload/airline/themes/base16.vim)
 


### PR DESCRIPTION
Colors match the ones on normal statusbar

![Screenshot 2021-09-11 at 19 34 54](https://user-images.githubusercontent.com/4548767/132955023-11d0f80d-af91-4a75-9d13-1c92c3888f7c.png)
![Screenshot 2021-09-11 at 19 35 17](https://user-images.githubusercontent.com/4548767/132955025-b409a34e-c2d2-415f-9d3f-915cb19d7d56.png)
![Screenshot 2021-09-11 at 19 35 31](https://user-images.githubusercontent.com/4548767/132955027-0f690a64-7971-4308-b78b-296156886c6f.png)
![Screenshot 2021-09-11 at 19 36 59](https://user-images.githubusercontent.com/4548767/132955029-64275520-fdb9-4c26-8e4b-ee1cad055f49.png)
