### PR TITLE
Fix incorrect gui colors in jellybeans theme

### DIFF
--- a/autoload/airline/themes/jellybeans.vim
+++ b/autoload/airline/themes/jellybeans.vim
@@ -51,7 +51,7 @@ let g:airline#themes#jellybeans#palette.normal_modified = s:modified
 " Insert mode
 let s:I1 = [ s:guiWhite , s:gui0B , s:ctermWhite , s:cterm0B  ]
 let s:I2 = s:N2
-let s:I3 = [ s:guiWhite , s:gui01 , s:ctermWhite , s:cterm00  ]
+let s:I3 = [ s:guiWhite , s:gui00 , s:ctermWhite , s:cterm00  ]
 let g:airline#themes#jellybeans#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
 let g:airline#themes#jellybeans#palette.insert_modified = s:modified
 
@@ -63,7 +63,7 @@ let g:airline#themes#jellybeans#palette.visual = airline#themes#generate_color_m
 let g:airline#themes#jellybeans#palette.visual_modified = s:modified
 
 " Replace mode
-let s:R1 = [ s:gui08 , s:gui01 , s:cterm08, s:cterm00 ]
+let s:R1 = [ s:gui08 , s:gui00 , s:cterm08, s:cterm00 ]
 let s:R2 = s:N2
 let s:R3 = s:I3
 let g:airline#themes#jellybeans#palette.replace = airline#themes#generate_color_map(s:R1, s:R2, s:R3)


### PR DESCRIPTION
I've noticed incorrect section colors when using `set termguicolors` with jellybeans theme.
It can easily be seen that gui colors are respectively defined as cterm colors except for several cases, this PR fixes this :) The issue was similar in both insert and replace mode. Attached herewith an illustration for insert mode.

Before proposed fix, it looked like this:
![before_fix](https://user-images.githubusercontent.com/99412607/155388558-f74b6807-0931-43c6-8e60-790b25595e3d.jpg)

After proposed fix, it looks correct:
![after_fix](https://user-images.githubusercontent.com/99412607/155388603-59cc5a2d-9df1-42a4-85fb-df68ccf81485.jpg)

Best,
gfszr


