### PR TITLE
Fixes colouring in base16 for INSERT/VISUAL

### DIFF
--- a/autoload/airline/themes/base16.vim
+++ b/autoload/airline/themes/base16.vim
@@ -92,7 +92,7 @@ else
           \ }
 
     let s:I1 = airline#themes#get_highlight2(['DiffText', 'bg'], ['DiffAdded', 'fg'], 'bold')
-    let s:I2 = airline#themes#get_highlight2(['DiffAdded', 'fg'], ['Normal', 'bg'])
+    let s:I2 = s:N2
     let s:I3 = s:N3
     let g:airline#themes#base16#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
     let g:airline#themes#base16#palette.insert_modified = g:airline#themes#base16#palette.normal_modified
@@ -104,7 +104,7 @@ else
     let g:airline#themes#base16#palette.replace_modified = g:airline#themes#base16#palette.normal_modified
 
     let s:V1 = airline#themes#get_highlight2(['DiffText', 'bg'], ['Constant', 'fg'], 'bold')
-    let s:V2 = airline#themes#get_highlight2(['Constant', 'fg'], ['Normal', 'bg'])
+    let s:V2 = s:N2
     let s:V3 = s:N3
     let g:airline#themes#base16#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
     let g:airline#themes#base16#palette.visual_modified = g:airline#themes#base16#palette.normal_modified


### PR DESCRIPTION
This fixes a colouring issue in the `base16` theme where `airline#themes#base16#constant` is not set or `0`.  In this mode the theme takes its colouring hints from the editor theme (which is Papercolor, in this case)

In the first screenshots (before) you can see that in insert mode (same issue in visual mode) there are black/grey arrowheads in the status-line and the colouring doesn't look consistent with other modes.

![image](https://user-images.githubusercontent.com/20093062/189499555-51c07724-6b25-413a-b5e0-335a6d3c0db8.png)

<img width="957" alt="image" src="https://user-images.githubusercontent.com/20093062/189499927-850b99d2-b43e-4058-9e61-99774fe7c649.png">


Here it is after. 

<img width="957" alt="image" src="https://user-images.githubusercontent.com/20093062/189499612-1ab2b67e-2ee4-4b22-b55d-695b78a8c25e.png">

<img width="957" alt="image" src="https://user-images.githubusercontent.com/20093062/189499908-54fe1b61-aebd-48fe-86df-d5ebc9d2ab5a.png">

